### PR TITLE
Refatoração do Cache da Camada de Serviço

### DIFF
--- a/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
+++ b/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
@@ -5,9 +5,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.util.StringUtils.hasText;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
@@ -23,28 +21,22 @@ public class PokemonSpiceService {
 
     private static final MeasureTime MEASURE_TIME = MINUTE;
 
-    private final Cache findAll;
-
-    private final Map<String, Cache> findByNameIgnoreCase;
+    private final PokemonSpiceRepository repository;
 
     public PokemonSpiceService(final PokemonSpiceRepository repository) {
-        findAll =  new Cache(TIME_INTERVAL, MEASURE_TIME, repository::findAll);
-        findByNameIgnoreCase = new HashMap<>();
+        final Cache cache = new Cache(TIME_INTERVAL, MEASURE_TIME, repository::findAll);
+        this.repository = () -> cache.<List<PokemonSpice>>getData().orGet(emptyList());
     }
 
     public List<PokemonSpice> findAll() {
-        return findAll.<List<PokemonSpice>>getData().orGet(emptyList()).stream().collect(toList());
+        return repository.findAll().stream().collect(toList());
     }
 
     public List<PokemonSpice> findByNameIgnoreCase(final String name) {
         return hasText(name)
-                ? findByNameIgnoreCase.computeIfAbsent(name.toLowerCase(), key -> {
-                    return new Cache(TIME_INTERVAL, MEASURE_TIME, () -> {
-                        return findAll().stream().filter(pokemonSpice -> {
-                            return pokemonSpice.getName().toLowerCase().contains(name.toLowerCase());
-                        }).collect(toList());
-                    });
-                }).<List<PokemonSpice>>getData().orGet(emptyList())
+                ? repository.findAll().stream().filter(pokemonSpice -> {
+                    return pokemonSpice.getName().toLowerCase().contains(name.toLowerCase());
+                }).collect(toList())
                 : emptyList();
     }
 

--- a/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
+++ b/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
@@ -25,11 +25,11 @@ public class PokemonSpiceService {
 
     public PokemonSpiceService(final PokemonSpiceRepository repository) {
         final Cache cache = new Cache(TIME_INTERVAL, MEASURE_TIME, repository::findAll);
-        this.repository = () -> cache.<List<PokemonSpice>>getData().orGet(emptyList());
+        this.repository = () -> cache.<List<PokemonSpice>>getData().orGet(emptyList()).stream().collect(toList());
     }
 
     public List<PokemonSpice> findAll() {
-        return repository.findAll().stream().collect(toList());
+        return repository.findAll();
     }
 
     public List<PokemonSpice> findByNameIgnoreCase(final String name) {


### PR DESCRIPTION
## Justificativa

Caches são comumente usados visando reduzir o tempo de consulta a dados cuja obtenção é consideravelmente lenta, pensando nisso, não faz sentido haverem caches aplicados a fontes que já são obtidas via cache, principalmente se a operação seguinte é veloz e pouco custosa.

## Detalhes

Desde o surgimento da camada de serviço, a classe `PokemonSpiceService` faz uso de cache em seus dois métodos, o problema disso é que embora `findByNameIgnoreCase` gerencie seu próprio cache, ele faz chamada ao método `findAll` que também gerencia seu próprio cache, ou seja, são dados de cache, fazendo uso de outros dados de cache. Desse modo, a partir de então nenhum método presente na camada de serviço fará gerenciamento direto de cache, sendo assim, o construtor de `PokemonSpiceService` passará então a de forma centralizada aplicar cache a instância de `PokemonSpiceRepository` conforme o construtor abaixo:
```
public PokemonSpiceService(final PokemonSpiceRepository repository) {
        final Cache cache = new Cache(TIME_INTERVAL, MEASURE_TIME, repository::findAll);
        this.repository = () -> cache.<List<PokemonSpice>>getData().orGet(emptyList()).stream().collect(toList());
}
```
Sendo assim, a única responsabilidade do método `findAll` é repassar os dados obtidos no repositório, bem como a única responsabilidade `findByNameIgnoreCase` é efetuar buscas. Lembrando que mesmo assim, ambos os métodos terão acesso de dados via cache.

## Referências
- #8 
- #6 