### PR TITLE
Configuração de Porta do Servidor

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=looqbox

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: looqbox

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: looqbox
+server:
+  port: 8080


### PR DESCRIPTION
## Justificativa
Considerando que a porta 80 é comumente usada para estabelecer tráfego de dados oriundos da internet, normalmente não é possível utiliza-la e considerando que o SpringBoot vem com ela configurada por padrão se faz necessário alterar isso para uma porta alternativa, nesse caso, escolhi a tradicional 8080.

## Detalhes
Num primeiro momento, o arquivo de configuração do SpringBoot `application.properties` foi removido dando lugar ao `application.yml`, no fim ambos funcionam da mesma maneira, porém julgo a formatação `yml` mais simples e organizada.
Num segundo momento, o recém criado arquivo de configuração `application.yml` passou a definir a porta 8080 como a padrão a ser usada no SpringBoot, evitando assim eventuais conflitos com a porta 80.

## Referências

- #1 