### PR TITLE
Adicionando Dependências Ao SpringBoot

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,7 +18,9 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.google.code.gson:gson:2.11.0'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
## Justificativa
No decorrer do desenvolvimento do projeto houve a necessidade de adicionar três dependências, seja visando desde possibilitar que a API desempenhe tarefas básicas, até possibilitando a execução de testes.

## Detalhes
Essa sessão, busca explicar quais foram as três dependências adicionadas e o papel desempenhado por cada uma delas.
- `org.springframework.boot:spring-boot-starter-web` a dependência `spring-boot-starter-web` é essencial no Spring Boot para criar aplicações web e APIs REST. Ela configura automaticamente o Spring MVC, suporte a JSON via Jackson e servidores embutidos como Tomcat, simplificando o desenvolvimento. Além disso, inclui ferramentas para roteamento, validação, tratamento de exceções e outras funcionalidades essenciais para aplicações modernas.
- `com.google.code.gson:gson:2.11.0` A dependência `gson` facilita a conversão entre objetos Java e JSON de forma simples e eficiente. Ela suporta serialização, desserialização, manipulação de tipos genéricos, além de ser altamente configurável e leve, tornando-se ideal para aplicações que requerem processamento de JSON. A versão 2.11.0 inclui melhorias e correções recentes.
- `com.squareup.okhttp3:mockwebserver:4.11.0` A dependência `mockwebserver` é útil para testes de aplicações que fazem chamadas HTTP, permitindo simular servidores e responder com dados controlados. Ela facilita a validação de requisições e respostas, garantindo a funcionalidade do cliente HTTP. A versão 4.11.0 oferece melhorias recentes, sendo altamente confiável e amplamente usada em testes automatizados.

## Referências
- #1 