### PR TITLE
Correção de NullPointerException em Ordenações MergeSort

### DIFF
--- a/backend/src/main/java/github/evertonbrunosds/looqbox/util/MergeSort.java
+++ b/backend/src/main/java/github/evertonbrunosds/looqbox/util/MergeSort.java
@@ -37,9 +37,9 @@ public class MergeSort<T> {
      * naturalmente no Java.
      */
     public MergeSort() {
-        comparer = (final T leftElement, final T rightElement) -> {
+        this((leftElement, rightElement) -> {
             return compare(leftElement.hashCode(), rightElement.hashCode());
-        };
+        });
     }
 
     /**
@@ -57,7 +57,15 @@ public class MergeSort<T> {
      *                 qualquer forma imaginável.
      */
     public MergeSort(final Comparer<T, T, Integer> comparer) {
-        this.comparer = comparer;
+        this.comparer = (leftElement, rightElement) -> {
+            return leftElement != null && rightElement != null
+                    ? comparer.compare(leftElement, rightElement)
+                    : leftElement == null && rightElement != null
+                            ? -1
+                            : leftElement != null && rightElement == null
+                                    ? 1
+                                    : 0;
+        };
     }
 
     /**

--- a/backend/src/test/java/github/evertonbrunosds/looqbox/util/MergeSortTest.java
+++ b/backend/src/test/java/github/evertonbrunosds/looqbox/util/MergeSortTest.java
@@ -3,6 +3,7 @@ package github.evertonbrunosds.looqbox.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -10,11 +11,29 @@ import org.junit.jupiter.api.Test;
 public class MergeSortTest {
 
     @Test
+    public void ascendingSortForIntegerWithNullElementAndNoArgumentsInTheConstructorTest() {
+        final List<Integer> target = Arrays.asList(new Integer[]{null, 1, 4, 2, 5});
+        final List<Integer> expected = Arrays.asList(new Integer[]{null, 1, 2, 4, 5});
+        final MergeSort<Integer> mergeSort = new MergeSort<>(); // sem argumento no construtor
+        mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
     public void ascendingSortForIntegerWithNoArgumentsInTheConstructorTest() {
         final List<Integer> target = new ArrayList<>(List.of(3, 1, 4, 2, 5));
         final List<Integer> expected = List.of(1, 2, 3, 4, 5);
         final MergeSort<Integer> mergeSort = new MergeSort<>(); // sem argumento no construtor
         mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
+    public void descendingSortForIntegerWithNullElementAndNoArgumentsInTheConstructorTest() {
+        final List<Integer> target = Arrays.asList(new Integer[]{null, 1, 4, 2, 5});
+        final List<Integer> expected = Arrays.asList(new Integer[]{5, 4, 2, 1, null});
+        final MergeSort<Integer> mergeSort = new MergeSort<>(); // sem argumento no construtor
+        mergeSort.sort(target, true); // ordenação descendente (reversa)
         assertEquals(expected, target);
     }
 
@@ -28,11 +47,29 @@ public class MergeSortTest {
     }
 
     @Test
+    public void ascendingSortForStringWithNullElementNoArgumentsInTheConstructorTest() {
+        final List<String> target = Arrays.asList(new String[]{"C", "A", "D", null, "E"});
+        final List<String> expected = Arrays.asList(new String[]{null, "A", "C", "D", "E"});
+        final MergeSort<String> mergeSort = new MergeSort<>(); // sem argumento no construtor
+        mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
     public void ascendingSortForStringWithNoArgumentsInTheConstructorTest() {
         final List<String> target = new ArrayList<>(List.of("C", "A", "D", "B", "E"));
         final List<String> expected = List.of("A", "B", "C", "D", "E");
         final MergeSort<String> mergeSort = new MergeSort<>(); // sem argumento no construtor
         mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
+    public void descendingSortForStringWithNullElementNoArgumentsInTheConstructorTest() {
+        final List<String> target = Arrays.asList(new String[]{"C", "A", "D", null, "E"});
+        final List<String> expected = Arrays.asList(new String[]{"E", "D", "C", "A", null});
+        final MergeSort<String> mergeSort = new MergeSort<>(); // sem argumento no construtor
+        mergeSort.sort(target, true); // ordenação descendente (reversa)
         assertEquals(expected, target);
     }
 
@@ -46,11 +83,29 @@ public class MergeSortTest {
     }
 
     @Test
+    public void ascendingSortForIntegerWithNullElementArgumentsInTheConstructorTest() {
+        final List<Integer> target = Arrays.asList(new Integer[]{3, null, null, 2, 5});
+        final List<Integer> expected = Arrays.asList(new Integer[]{null,null, 2, 3, 5});
+        final MergeSort<Integer> mergeSort = new MergeSort<>(Integer::compareTo); // com argumento no construtor
+        mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
     public void ascendingSortForIntegerWithArgumentsInTheConstructorTest() {
         final List<Integer> target = new ArrayList<>(List.of(3, 1, 4, 2, 5));
         final List<Integer> expected = List.of(1, 2, 3, 4, 5);
         final MergeSort<Integer> mergeSort = new MergeSort<>(Integer::compareTo); // com argumento no construtor
         mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
+    public void descendingSortForIntegerWithNullElementArgumentsInTheConstructorTest() {
+        final List<Integer> target = Arrays.asList(new Integer[]{3, null, null, 2, 5});
+        final List<Integer> expected = Arrays.asList(new Integer[]{5, 3, 2, null,null});
+        final MergeSort<Integer> mergeSort = new MergeSort<>(Integer::compareTo); // com argumento no construtor
+        mergeSort.sort(target, true); // ordenação descendente (reversa)
         assertEquals(expected, target);
     }
 
@@ -64,11 +119,29 @@ public class MergeSortTest {
     }
 
     @Test
+    public void ascendingSortForStringWithNullElementArgumentsInTheConstructorTest() {
+        final List<String> target = Arrays.asList(new String[]{"C", null, "D", null, "E"});
+        final List<String> expected = Arrays.asList(new String[]{null, null, "C", "D", "E"});
+        final MergeSort<String> mergeSort = new MergeSort<>(String::compareTo); // com argumento no construtor
+        mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
     public void ascendingSortForStringWithArgumentsInTheConstructorTest() {
         final List<String> target = new ArrayList<>(List.of("C", "A", "D", "B", "E"));
         final List<String> expected = List.of("A", "B", "C", "D", "E");
         final MergeSort<String> mergeSort = new MergeSort<>(String::compareTo); // com argumento no construtor
         mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
+    public void descendingSortForStringWithNullElementArgumentsInTheConstructorTest() {
+        final List<String> target = Arrays.asList(new String[]{"C", null, "D", null, "E"});
+        final List<String> expected = Arrays.asList(new String[]{"E", "D", "C", null, null});
+        final MergeSort<String> mergeSort = new MergeSort<>(String::compareTo); // com argumento no construtor
+        mergeSort.sort(target, true); // ordenação descendente (reversa)
         assertEquals(expected, target);
     }
 
@@ -81,6 +154,14 @@ public class MergeSortTest {
         assertEquals(expected, target);
     }
 
+    @Test
+    public void ascendingSortForStringLengthWithNullElement() {
+        final List<String> target = Arrays.asList(new String[]{"AA", "BBBB", "C", null, null});
+        final List<String> expected = Arrays.asList(new String[]{null, null, "C", "AA", "BBBB"});
+        final MergeSort<String> mergeSort = new MergeSort<>((a, b) -> Integer.compare(a.length(), b.length())); // com argumento no construtor
+        mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
 
     @Test
     public void ascendingSortForStringLength() {
@@ -88,6 +169,15 @@ public class MergeSortTest {
         final List<String> expected = List.of("C", "AA", "DDD", "BBBB", "EEEEE");
         final MergeSort<String> mergeSort = new MergeSort<>((a, b) -> Integer.compare(a.length(), b.length())); // com argumento no construtor
         mergeSort.sort(target, false); // ordenação ascendente (não reversa)
+        assertEquals(expected, target);
+    }
+
+    @Test
+    public void descendingSortForStringLengthNullElement() {
+        final List<String> target = Arrays.asList(new String[]{"AA", "BBBB", "C", null, null});
+        final List<String> expected = Arrays.asList(new String[]{"BBBB", "AA", "C", null, null});
+        final MergeSort<String> mergeSort = new MergeSort<>((a, b) -> Integer.compare(a.length(), b.length())); // com argumento no construtor
+        mergeSort.sort(target, true); // ordenação descendente (reversa)
         assertEquals(expected, target);
     }
 


### PR DESCRIPTION
## Justificativa
Anteriormente o algoritmo merge sort presente na classe `MergeSort` não estava sendo capaz de ordenar listas em que estavam presentes eventuais elementos nulos, o que por ventura acabava por disparar exceção de ponteiro nulo. Então, visando tornar a ordenação ainda mais abrangente, ela passará a se tornar capaz de ordenar elementos nulos em instâncias do `MergeSort` obtidas via construtor sem com e parâmetros.
Considerando o problema proposto, acredito que nunca haverá um pokemon cujo nome encontra-se nulo, porém a resolução desse bug nos traz vantagem em momentos futuros em que o `MergeSort` terá que eventualmente ordenar listas com elementos possivelmente nulos, o que torna a classe `MergeSort` mais confiável e mais dinâmica em cenários diversos.

## Detalhes
O construtor sem parâmetros passa a fazer o uso do construtor com parâmetros por meio do acesso `this`, já no construtor com parâmetros, esse simplesmente definiu algumas verificações, que podem ser observadas abaixo:
```
public MergeSort(final Comparer<T, T, Integer> comparer) {
    this.comparer = (leftElement, rightElement) -> {
        return leftElement != null && rightElement != null
            ? comparer.compare(leftElement, rightElement)
             : leftElement == null && rightElement != null
                    ? -1
                    : leftElement != null && rightElement == null
                             ? 1
                             : 0;
    };
} 
```

## Referências
- #5 