### PR TITLE
Configuração da Imagem Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk as builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN ./gradlew clean build -x test
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+ENV CACHE_TIME_INTERVAL_CONTROLLER=15 \
+    CACHE_TIME_INTERVAL_SERVICE=5 \
+    CACHE_TIME_MEASURE_CONTROLLER=MINUTE \
+    CACHE_TIME_MEASURE_SERVICE=HOUR
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Justificativa

O uso de Docker em projetos de backend oferece inúmeros benefícios, como portabilidade e consistência entre ambientes de desenvolvimento, teste e produção. Com ele, é possível criar imagens imutáveis contendo todas as dependências do projeto, eliminando problemas de configuração ou conflitos de versões. Além disso, Docker facilita a escalabilidade, permitindo que serviços sejam rapidamente replicados em contêineres independentes. A integração com ferramentas de CI/CD simplifica o processo de deploy contínuo, garantindo entregas rápidas e confiáveis. Por ser leve e eficiente, Docker reduz custos operacionais, tornando-se uma solução poderosa para gerenciar aplicações backend de forma moderna e ágil.

## Detalhes
A imagem docker desenvolvida para o backend do projeto não apenas fornece uma versão utilizável do projeto, uma vez que permite ao utilizador configurar os tempos de cache determinados nas camadas de serviço e de controle, o que traz muita dinamicidade ao projeto.
1. Crie uma imagem docker do projeto com o comando `docker build -t looqbox .` no diretório `backend`.
2. Execute a imagem criada determinando a porta exposta, a porta da instância, configurações de cache e nome da instância confirme o código abaixo:
```
docker run -d -p 80:8080 \
    -e CACHE_TIME_INTERVAL_CONTROLLER=5 \
    -e CACHE_TIME_INTERVAL_SERVICE=10 \
    -e CACHE_TIME_MEASURE_CONTROLLER=MINUTE \
    -e CACHE_TIME_MEASURE_SERVICE=HOUR \
    --name pokemon-microservice \
    looqbox
```
   - A porta configurada no SpringBoot é sempre a `8080`, logo a porta exposta na imagem docker também é `8080`.
   - A porta da instância da imagem docker pode ser a de sua preferência, para esse exemplo, escolhi a `80`.
   - Em seguida, tanto na variável de ambiente `CACHE_TIME_INTERVAL_CONTROLLER`, quanto `CACHE_TIME_INTERVAL_SERVICE`, você pode configurar os intervalos de tempo de atualização dos caches presentes nas camadas de serviço e controle, caso não declare `CACHE_TIME_INTERVAL_CONTROLLER`, seu valor padrão será `15` e caso não declare `CACHE_TIME_INTERVAL_SERVICE`, seu valor padrão será `5`.
   - Adiante, tanto na variável de ambiente `CACHE_TIME_MEASURE_CONTROLLER`, quanto `CACHE_TIME_MEASURE_SERVICE`, você pode configurar as medidas de tempo para os intervalos de tempo anteriormente declarados, quanto a isso, você pode escolher um dentre três valores, sendo eles: `SECOND`, `MINUTE` e `HOUR`. Caso não declare `CACHE_TIME_MEASURE_CONTROLLER`, seu valor padrão é `MINUTE` e caso não declare `CACHE_TIME_MEASURE_SERVICE`, seu valor padrão é `HOUR`.
   - Por fim, defina o nome da instância e a imagem docker de origem.
  
Talvez pareça um capricho, mas considerando que o cache usado é definido por tempo, achei prudente dar ao desenvolvedor a oportunidade de configurar o tempo sem que haja a necessidade de fazer alterações no código fonte. Além disso, especular qual tempo seria o ideal para os caches não me parece relevante num primeiro momento.

## Referências
- #6 
- #15 
- #10 
- #8 
- #12 