### PR TITLE
Refatoração do Cache nas Camadas de Serviço e Controle para ser Configurado via Variáveis de Ambiente

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk as builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN ./gradlew clean build -x test
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+ENV CACHE_TIME_INTERVAL_CONTROLLER=15 \
+    CACHE_TIME_INTERVAL_SERVICE=5 \
+    CACHE_TIME_MEASURE_CONTROLLER=MINUTE \
+    CACHE_TIME_MEASURE_SERVICE=HOUR
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
+++ b/backend/src/main/java/github/evertonbrunosds/looqbox/service/PokemonSpiceService.java
@@ -1,30 +1,29 @@
 package github.evertonbrunosds.looqbox.service;
 
-import static github.evertonbrunosds.looqbox.util.Cache.MeasureTime.MINUTE;
+import static github.evertonbrunosds.looqbox.util.Cache.TimeMeasure.HOUR;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.util.StringUtils.hasText;
 
 import java.util.List;
 
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import github.evertonbrunosds.looqbox.model.PokemonSpice;
 import github.evertonbrunosds.looqbox.repository.PokemonSpiceRepository;
 import github.evertonbrunosds.looqbox.util.Cache;
-import github.evertonbrunosds.looqbox.util.Cache.MeasureTime;
+import github.evertonbrunosds.looqbox.util.Cache.TimeMeasure;
 
 @Service
 public class PokemonSpiceService {
 
-    private static final int TIME_INTERVAL = 1;
-
-    private static final MeasureTime MEASURE_TIME = MINUTE;
-
     private final PokemonSpiceRepository repository;
 
-    public PokemonSpiceService(final PokemonSpiceRepository repository) {
-        final Cache cache = new Cache(TIME_INTERVAL, MEASURE_TIME, repository::findAll);
+    public PokemonSpiceService(final PokemonSpiceRepository repository, final Environment environment) {
+        final int timeInterval = environment.getProperty("cache.time.interval.service", Integer.class,5);
+        final TimeMeasure timeMeasure = environment.getProperty("cache.time.measure.service", TimeMeasure.class, HOUR);
+        final Cache cache = new Cache(timeInterval, timeMeasure, repository::findAll);
         this.repository = () -> cache.<List<PokemonSpice>>getData().orGet(emptyList()).stream().collect(toList());
     }
 

--- a/backend/src/main/java/github/evertonbrunosds/looqbox/util/Cache.java
+++ b/backend/src/main/java/github/evertonbrunosds/looqbox/util/Cache.java
@@ -14,9 +14,9 @@ public class Cache {
 
     private final Process<?> onUpdate;
 
-    private final MeasureTime measureTime;
+    private final TimeMeasure timeMeasure;
 
-    public Cache(final long timeInterval, final MeasureTime measureTime, final Process<?> onUpdate) {
+    public Cache(final long timeInterval, final TimeMeasure timeMeasure, final Process<?> onUpdate) {
         if (timeInterval <= 0) {
             throw new InvalidParameterException("the 'timeInterval' parameter must be greater than zero");
         }
@@ -24,7 +24,7 @@ public class Cache {
         this.invalidAt = LocalDateTime.now();
         this.timeInterval = timeInterval;
         this.onUpdate = onUpdate;
-        this.measureTime = measureTime;
+        this.timeMeasure = timeMeasure;
     }
 
     @SuppressWarnings("unchecked")
@@ -33,7 +33,7 @@ public class Cache {
         try {
             if (updateData) {
                 data = onUpdate.get();
-                switch (measureTime) {
+                switch (timeMeasure) {
                     case SECOND:
                         invalidAt = LocalDateTime.now().plusSeconds(timeInterval);
                         break;
@@ -59,7 +59,7 @@ public class Cache {
 
     }
 
-    public enum MeasureTime {
+    public enum TimeMeasure {
         SECOND, MINUTE, HOUR
     }
 

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{"properties": [
+  {
+    "name": "cache.time.interval.controller",
+    "type": "java.lang.Integer",
+    "description": "it refers to the cached time interval present in the controller"
+  },
+  {
+    "name": "cache.time.interval.service",
+    "type": "java.lang.Integer",
+    "description": "it refers to the cached time interval present in the service"
+  },
+  {
+    "name": "cache.time.measure.controller",
+    "type": "github.evertonbrunosds.looqbox.util.Cache.TimeMeasure",
+    "description": "it refers to the cached time measurement present in the controller"
+  },
+  {
+    "name": "cache.time.measure.service",
+    "type": "github.evertonbrunosds.looqbox.util.Cache.TimeMeasure",
+    "description": "it refers to the cached time measurement present in the service"
+  }
+]}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,5 +3,15 @@ spring:
     active: main
   application:
     name: looqbox
+
 server:
   port: 8080
+
+cache:
+  time:
+    interval:
+      controller: ${CACHE_TIME_INTERVAL_CONTROLLER}
+      service: ${CACHE_TIME_INTERVAL_SERVICE}
+    measure:
+      controller: ${CACHE_TIME_MEASURE_CONTROLLER}
+      service: ${CACHE_TIME_MEASURE_SERVICE}

--- a/backend/src/test/java/github/evertonbrunosds/looqbox/service/PokemonSpiceServiceTest.java
+++ b/backend/src/test/java/github/evertonbrunosds/looqbox/service/PokemonSpiceServiceTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 import github.evertonbrunosds.looqbox.configuration.PokemonSpiceRepositoryConfiguration;
 import github.evertonbrunosds.looqbox.configuration.PokemonSpiceRepositoryConfiguration.SimpleHttpResponse;
@@ -62,7 +66,7 @@ public class PokemonSpiceServiceTest {
         final SimpleRequestMaker simpleRequestMaker = (url) -> new SimpleHttpResponse(statusCode, successBody());
         final PokemonSpiceRepositoryConfiguration configuration = new PokemonSpiceRepositoryConfiguration(simpleRequestMaker);
         final PokemonSpiceRepository repository = configuration.pokemonSpiceRepository();
-        final PokemonSpiceService service = new PokemonSpiceService(repository);
+        final PokemonSpiceService service = new PokemonSpiceService(repository, environment());
         return service;
     }
 
@@ -4176,6 +4180,87 @@ public class PokemonSpiceServiceTest {
                     ]
                 }
                 """;
+    }
+
+    private static final Environment environment() {
+        return new Environment() {
+
+            @Override
+            public boolean containsProperty(final @Nullable String key) {
+                throw new UnsupportedOperationException("Unimplemented method 'containsProperty'");
+            }
+
+            @Override
+            @Nullable
+            public String getProperty(final @Nullable String key) {
+                throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+            }
+
+            @NonNull
+            @Override
+            public String getProperty(final @Nullable String key, final @Nullable String defaultValue) {
+                throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+            }
+
+            @Override
+            @Nullable
+            public <T> T getProperty(final @Nullable String key, final @Nullable Class<T> targetType) {
+                throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+            }
+
+            @NonNull
+            @Override
+            public <T> T getProperty(final @Nullable String key, final @Nullable Class<T> targetType, final @NonNull T defaultValue) {
+                return defaultValue;
+            }
+
+            @NonNull
+            @Override
+            public String getRequiredProperty(final @Nullable String key) throws IllegalStateException {
+                throw new UnsupportedOperationException("Unimplemented method 'getRequiredProperty'");
+            }
+
+            @NonNull
+            @Override
+            public <T> T getRequiredProperty(final @Nullable String key, final @Nullable Class<T> targetType) throws IllegalStateException {
+                throw new UnsupportedOperationException("Unimplemented method 'getRequiredProperty'");
+            }
+
+            @NonNull
+            @Override
+            public String resolvePlaceholders(final @Nullable String text) {
+                throw new UnsupportedOperationException("Unimplemented method 'resolvePlaceholders'");
+            }
+
+            @NonNull
+            @Override
+            public String resolveRequiredPlaceholders(final @Nullable String text) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Unimplemented method 'resolveRequiredPlaceholders'");
+            }
+
+            @NonNull
+            @Override
+            public String[] getActiveProfiles() {
+                throw new UnsupportedOperationException("Unimplemented method 'getActiveProfiles'");
+            }
+
+            @NonNull
+            @Override
+            public String[] getDefaultProfiles() {
+                throw new UnsupportedOperationException("Unimplemented method 'getDefaultProfiles'");
+            }
+
+            @Override
+            public boolean acceptsProfiles(final @Nullable String... profiles) {
+                throw new UnsupportedOperationException("Unimplemented method 'acceptsProfiles'");
+            }
+
+            @Override
+            public boolean acceptsProfiles(final @Nullable Profiles profiles) {
+                throw new UnsupportedOperationException("Unimplemented method 'acceptsProfiles'");
+            }
+
+        };
     }
 
 }

--- a/backend/src/test/java/github/evertonbrunosds/looqbox/util/CacheTest.java
+++ b/backend/src/test/java/github/evertonbrunosds/looqbox/util/CacheTest.java
@@ -7,7 +7,7 @@ import java.security.InvalidParameterException;
 
 import org.junit.jupiter.api.Test;
 
-import github.evertonbrunosds.looqbox.util.Cache.MeasureTime;
+import github.evertonbrunosds.looqbox.util.Cache.TimeMeasure;
 
 public class CacheTest {
 
@@ -28,7 +28,7 @@ public class CacheTest {
         final Counter counter = new Counter(); // simula um processo custoso que deve ser armazenado em cache
         final int timeInterval = 1;
         final Cache.Process<?> onUpdate = counter::value; // o determina o que deve ocorrer ao atualizar o cache
-        final Cache cache = new Cache(timeInterval, MeasureTime.SECOND, onUpdate);
+        final Cache cache = new Cache(timeInterval, TimeMeasure.SECOND, onUpdate);
 
         // verifica mil vezes se o valor contido em cache se mantém sendo 0 (zero)
         expected = 0;
@@ -64,7 +64,7 @@ public class CacheTest {
         final Cache.Process<?> onUpdate = () -> {
             throw new NullPointerException();
         };
-        final Cache cache = new Cache(timeInterval, MeasureTime.SECOND, onUpdate);
+        final Cache cache = new Cache(timeInterval, TimeMeasure.SECOND, onUpdate);
         int expected = 5;
         assertEquals(expected, cache.<Integer>getData().orGet(5));
 
@@ -73,7 +73,7 @@ public class CacheTest {
     @Test
     public void invalidIntervalOnConstructorTest() {
         try {
-            new Cache(0, MeasureTime.SECOND, () -> 5);
+            new Cache(0, TimeMeasure.SECOND, () -> 5);
             fail();
         } catch(InvalidParameterException exception) {
             final String expected = "the 'timeInterval' parameter must be greater than zero";


### PR DESCRIPTION
## Justificativa
Considerando que o cache em seu atual estado se baseia não em quantidade de uso, mas sim em tempo de validade. Me parece num primeiro instante desnecessária a discussão de qual seria o tempo ideal para os caches presentes nas camadas de controle e serviço. Com isso, a solução encontrada foi dinamizar esse processo de tal modo que seja possível configurar os tempos de cache sem que seja necessário fazer alterações no código. Nesse sentido, a solução encontrada foi configurar os caches por meio das variáveis de ambiente, o que futuramente nos permitirá criar os tempos de cache que bem quisermos em diferentes instâncias de imagens docker.

## Detalhes
Bom, por arqui não tem muito detalhe, no momento de definir as medidas e os intervalos de tempo para configurar os caches das camadas de serviço e controle, esses dados vem de variáveis de ambiente conforme a configuração atual do `application.yml`:
```
cache:
  time:
    interval:
      controller: ${CACHE_TIME_INTERVAL_CONTROLLER}
      service: ${CACHE_TIME_INTERVAL_SERVICE}
    measure:
      controller: ${CACHE_TIME_MEASURE_CONTROLLER}
      service: ${CACHE_TIME_MEASURE_SERVICE}
```
- As variáveis de ambiente `CACHE_TIME_INTERVAL_CONTROLLER` e `CACHE_TIME_INTERVAL_SERVICE`, devem conter valores numéricos maiores ou iguais a zero, caso não especificados, seus valores padrões em código são respectivamente 15 e 5.
- As variáveis de ambiente`CACHE_TIME_MEASURE_CONTROLLER` e `CACHE_TIME_MEASURE_SERVICE`, devem conter um dentre três valores `SECOND`, `MINUTE` e `HOUR`, caso não especificados, seus valores padrões em código são respectivamente `MINUTE` e `HOUR`.

## Referências
- #6 
- #8 
- #12 